### PR TITLE
Note and test more installation options for $DNF_INSTALL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - docker run --rm -it -v $PWD/example_project:/src -w /src -e TOXENV -e TOX_PARAMS="-p auto" fedorapython/fedora-python-tox
   # Test that we can install (multiple) packages from DNF as devel dependencies. Without those, cffi and pyaml are not installable from sources.
   # This test overrides the entrypoint, so it has to be specified manually as the first command. It always runs system pip.
-  - 'docker run --rm -it -e DNF_INSTALL="libffi-devel pkgconfig(libffi) /usr/bin/cowsay" fedorapython/fedora-python-tox sh -c "/run_tests.sh; pip install -I --no-deps --compile --no-binary :all: cffi pyyaml && cowsay DONE"'
+  - 'docker run --rm -it -e DNF_INSTALL="libffi-devel pkgconfig(libgit2) /usr/bin/cowsay" fedorapython/fedora-python-tox sh -c "/run_tests.sh; pip install -I --no-deps --compile --no-binary :all: cffi pygit2 && cowsay DONE"'
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - docker run --rm -it -v $PWD/example_project:/src -w /src -e TOXENV -e TOX_PARAMS="-p auto" fedorapython/fedora-python-tox
   # Test that we can install (multiple) packages from DNF as devel dependencies. Without those, cffi and pyaml are not installable from sources.
   # This test overrides the entrypoint, so it has to be specified manually as the first command. It always runs system pip.
-  - 'docker run --rm -it -e DNF_INSTALL="libffi-devel libyaml-devel" fedorapython/fedora-python-tox sh -c "/run_tests.sh; pip install -I --no-deps --compile --no-binary :all: cffi pyyaml"'
+  - 'docker run --rm -it -e DNF_INSTALL="libffi-devel pkgconfig(libffi) /usr/bin/cowsay" fedorapython/fedora-python-tox sh -c "/run_tests.sh; pip install -I --no-deps --compile --no-binary :all: cffi pyyaml; cowsay DONE"'
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - docker run --rm -it -v $PWD/example_project:/src -w /src -e TOXENV -e TOX_PARAMS="-p auto" fedorapython/fedora-python-tox
   # Test that we can install (multiple) packages from DNF as devel dependencies. Without those, cffi and pyaml are not installable from sources.
   # This test overrides the entrypoint, so it has to be specified manually as the first command. It always runs system pip.
-  - 'docker run --rm -it -e DNF_INSTALL="libffi-devel pkgconfig(libffi) /usr/bin/cowsay" fedorapython/fedora-python-tox sh -c "/run_tests.sh; pip install -I --no-deps --compile --no-binary :all: cffi pyyaml; cowsay DONE"'
+  - 'docker run --rm -it -e DNF_INSTALL="libffi-devel pkgconfig(libffi) /usr/bin/cowsay" fedorapython/fedora-python-tox sh -c "/run_tests.sh; pip install -I --no-deps --compile --no-binary :all: cffi pyyaml && cowsay DONE"'
 
 matrix:
   include:

--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ py27 create: /src/.tox/py27
 ...
 ```
 
+You can install packages by any RPM *Provides*, for example:
+
+* Fedora package names, e.g. `libgit2-devel`,
+* pkgconfig names, e.g. `pkgconfig(libgit2)`, or
+* commands, e.g. `/usr/bin/cowsay`.
+
 # License
 
 MIT


### PR DESCRIPTION
This should be usable for people who aren't that familiar with
Fedora/RPM/DNF, so I believe it's good to document and test
some interesting things you can give to $DNF_INSTALL.
(Especially the ones that use more cross-platform namespaces:
pkgconfig and command names.)