### PR TITLE
Build and deploy docker images for all supported architectures with manifest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,62 @@
+language: generic
+
 services:
   - docker
 
 before_install:
-  - docker build -t fedorapython/fedora-python-tox .
+  - docker build -t fedorapython/fedora-python-tox:$TRAVIS_CPU_ARCH .
   - docker images
 
 script:
   # Test project in local folder mounted as a volume into Docker container
-  - docker run --rm -v $PWD/example_project:/src -w /src -e TOXENV fedorapython/fedora-python-tox
+  - docker run --rm -v $PWD/example_project:/src -w /src -e TOXENV fedorapython/fedora-python-tox:$TRAVIS_CPU_ARCH
   # Test project cloned into Docker container from provided GIT URL
-  - docker run --rm -e TOXENV -e GIT_URL=https://github.com/frenzymadness/python-tox-example.git fedorapython/fedora-python-tox
+  - docker run --rm -e TOXENV -e GIT_URL=https://github.com/frenzymadness/python-tox-example.git fedorapython/fedora-python-tox:$TRAVIS_CPU_ARCH
   # Test in local folder in parallel
-  - docker run --rm -v $PWD/example_project:/src -w /src -e TOXENV -e TOX_PARAMS="-p auto" fedorapython/fedora-python-tox
+  - docker run --rm -v $PWD/example_project:/src -w /src -e TOXENV -e TOX_PARAMS="-p auto" fedorapython/fedora-python-tox:$TRAVIS_CPU_ARCH
   # Test that we can install (multiple) packages from DNF as devel dependencies. Without those, cffi and pygit2 are not installable from sources.
   # This test overrides the entrypoint, so it has to be specified manually as the first command. It always runs system pip.
-  - 'docker run --rm -e DNF_INSTALL="libffi-devel pkgconfig(libgit2) /usr/bin/cowsay" fedorapython/fedora-python-tox sh -c "/run_tests.sh; pip install -I --no-deps --compile --no-binary :all: cffi pygit2 && cowsay DONE"'
-
-matrix:
-  include:
-  - env: TOXENV=py36,py37,py38,py39
-  - env: TOXENV=py27,py34,py35,pypy,pypy3
-  # the above tests all available toxenvs run on amd64 (x86_64)
-  # we run *some* toxenvs on the other architectures as well:
-  - arch: arm64
-    env: TOXENV=py38,py39
-  - arch: ppc64le
-    env: TOXENV=py37,py38
-  - arch: s390x
-    env: TOXENV=py35,py36,py38,pypy3
+  - 'docker run --rm -e DNF_INSTALL="libffi-devel pkgconfig(libgit2) /usr/bin/cowsay" fedorapython/fedora-python-tox:$TRAVIS_CPU_ARCH sh -c "/run_tests.sh; pip install -I --no-deps --compile --no-binary :all: cffi pygit2 && cowsay DONE"'
 
 env:
   global:
     secure: g/Miy9Ll4KWqYxvp+F/qhrnXshr6Bdd51pSJiqioKGxJipILLyCWxpmqhQWAJjMfHD+lKzV7RjvZcxvaC5DCqKDghNb8HykQo+8HUpTClLQxgYXKuF9yHnX7kiMsQGUFp7Te6cffR+1bOFL7jtYKDmuwr5bp2MtxSrr6TJ/nKlFQLIGeWFtFIXqjjlJMvm/XqwfxAww0GCTKgJ32dYS8YLGrJw6VcR+KJ6z43ctdNqs0iVE1dYTfxMqlm4/2vPOT1AYQlj/OBMSARCPl+LkRTjHj2+oLjdJjRwdnqS/6lRbbiYrZGf/ANNPbbTndqGzqLm6SLLF7gKM9q97aTIw9OYRd3u4mbHKlU4uLcAzwLC4KCabp/wMT56j5d8ikxdsRPgFPu9XBjb7xe42ZkDWLVZ4qrYCyT3KIzA7/M4ryAQ/p8xqzaUTx/LIxEyk9kSrzHyzcqEdTOcjzh1UihTL7lg3gfy8A3PVBJUbcOhquPdHAoTwPchCKYoog/pt97Ju1rWGmaLKFvFD6ohlIQ24TH0rkZaKylchXZc4Lyk5YThHqOubqf/ujVfNLnPLYgUZsZLotHsU3LZgIjGIprgjlBpN/lxFByxBTd2n09HraUgDbJ6GECBjkf+Z4bftre86wBjoGbjzP4mkqMkfOSo2+sq6vro7HyJQmQsgzd6E8enU=
 
 after_success:
+  # Deploy images with $arch in tag to Docker hub
   - if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-      docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ;
-      docker push fedorapython/fedora-python-tox ;
+      docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD;
+      docker push fedorapython/fedora-python-tox:$TRAVIS_CPU_ARCH;
     fi
+
+jobs:
+  include:
+    - env: TOXENV=py36,py37,py38,py39
+    - env: TOXENV=py27,py34,py35,pypy,pypy3
+    # the above tests all available toxenvs run on amd64 (x86_64)
+    # we run *some* toxenvs on the other architectures as well:
+    - arch: arm64
+      env: TOXENV=py38,py39
+    - arch: ppc64le
+      env: TOXENV=py37,py38
+    - arch: s390x
+      env: TOXENV=py35,py36,py38,pypy3
+
+    - stage: deploy
+      if: branch = master AND type != pull_request
+      env: DOCKER_CLI_EXPERIMENTAL=enabled
+      before_install:
+        # Pull all the latest images for all architectures
+        - for arch in amd64 arm64 ppc64le s390x; do
+            docker pull fedorapython/fedora-python-tox:$arch;
+          done
+      script:
+        # Create and push manifest for the :latest tag
+        - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD;
+          docker manifest create fedorapython/fedora-python-tox:latest
+            fedorapython/fedora-python-tox:amd64
+            fedorapython/fedora-python-tox:arm64
+            fedorapython/fedora-python-tox:ppc64le
+            fedorapython/fedora-python-tox:s390x;
+          docker manifest push fedorapython/fedora-python-tox:latest;
+      after_success: # nothing


### PR DESCRIPTION
If all builds success, the new stage `deploy` creates a manifest for `:latest` tag and deploys it to Docker hub.

The last build done for my testing branch is here: https://travis-ci.org/github/fedora-python/fedora-python-tox/builds/727426556

There were no conditions in the configuration so the build produced all the images and the manifest we currently have in Docker hub. As far as I can tell, everything seems to be working.

On my machine:
```
# podman pull fedorapython/fedora-python-tox:latest
# podman inspect f22249e5ab81546d1f4f890bb5e814517bf44921c218bdf13167154ed7b5d302
…
        "Version": "18.06.0-ce",
        "Author": "",
        "Architecture": "amd64",
        "Os": "linux",
        "Size": 1283532376,
…
```

On s390x machine:
```
# podman pull fedorapython/fedora-python-tox:latest
# podman inspect  741ec96aac4573157ef8960c9d5994a6ad6563117fa313b29618bafb30af25ff
…
        "Version": "18.09.7",
        "Author": "",
        "Architecture": "s390x",
        "Os": "linux",
        "Size": 1278344277,
…
```

The current build for the branch I'm creating this PR from looks good as well but we'll see after the merge whether it deploys everything correctly or not.