### PR TITLE
Add a test for deployed manifest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,3 +60,12 @@ jobs:
             fedorapython/fedora-python-tox:s390x;
           docker manifest push fedorapython/fedora-python-tox:latest;
       after_success: # nothing
+
+    - stage: test_deployed_manifest
+      if: branch = master AND type != pull_request
+      env: DOCKER_CLI_EXPERIMENTAL=enabled
+      before_install:
+        - docker pull fedorapython/fedora-python-tox:latest;
+      script:
+        - docker manifest inspect fedorapython/fedora-python-tox:latest | grep '"architecture":' | grep -Ez '(.*(amd64|arm64|ppc64le|s390x).*){4}'
+      after_success: # nothing


### PR DESCRIPTION
For some reason, the latest `:latest` manifest built by cron did not contain `:s390x` in its definition even all commands in the build succeeded. A manual restart fixed it so the configuration should be okay.

This PR adds a check that the manifest contains all supported architecture. `docker manifest inspect` returns json like this:

```
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 949,
         "digest": "sha256:7f6beb6d44eea8c25ff8bef2e28318bc8dae3d390996fb8593ac668073e8f6b5",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 949,
         "digest": "sha256:07dfbf24149a051be9b1b4a1b7b19f20b6501fa83c006e89c13a154f623ee56b",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 949,
         "digest": "sha256:ef105db6039de2c6a8144f6051600a4eb2857c9363a3140312432afcda8e8ac3",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 949,
         "digest": "sha256:56f9e27d17a7986030a3f816a30f503acf57aac3a07f5127cfbacc4e48ea1c3f",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      }
   ]
}
```

So the `grep` command I've created should end with return code 1 if it cannot find four architectures in the manifest.

This PR won't test it, we have to merge it to actually test it.