### PR TITLE
Python 3.11 is now built with subpackages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN dnf update -y \
     python3.8 \
     python3.9 \
     python3.10 \
-    python3.11 \
+    python3.11-devel \
     python3-pip \
     /usr/bin/tox \
     /usr/bin/virtualenv \


### PR DESCRIPTION
See https://src.fedoraproject.org/rpms/python3.11/pull-request/26