### PR TITLE
Mark the repo as safe for Git

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -13,4 +13,7 @@ if [ ! -z "$DNF_INSTALL" ]; then
     dnf -y --setopt=tsflags=nodocs --setopt=deltarpm=false install $DNF_INSTALL
 fi
 
+# Mark the current directory as safe for Git:
+git config --global --add safe.directory `pwd`
+
 /usr/bin/tox $TOX_PARAMS

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -14,6 +14,6 @@ if [ ! -z "$DNF_INSTALL" ]; then
 fi
 
 # Mark the current directory as safe for Git:
-git --git-dir=~ config --global --add safe.directory $PWD
+git --git-dir=~ config --system --add safe.directory $PWD
 
 /usr/bin/tox $TOX_PARAMS

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -14,6 +14,6 @@ if [ ! -z "$DNF_INSTALL" ]; then
 fi
 
 # Mark the current directory as safe for Git:
-git config --global --add safe.directory `pwd`
+git --git-dir=~ config --global --add safe.directory $PWD
 
 /usr/bin/tox $TOX_PARAMS


### PR DESCRIPTION
This relates to https://github.com/actions/checkout/issues/760

Some tests need git to be functional (eg pre-commit checks) and since CVE-2022-24765 git checks directory ownership.