### PR TITLE
Use versioned tags to identify Fedora version we use

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: '48 23 * * 6'
 
+env:
+  FEDORA_VERSION: 34
+
 jobs:
   build-and-push:
     name: Build, test and push
@@ -38,7 +41,9 @@ jobs:
           context: .
           platforms: linux/${{ matrix.arch }}
           load: true
-          tags: fedorapython/fedora-python-tox:${{ matrix.arch }}
+          tags: |
+            fedorapython/fedora-python-tox:${{ matrix.arch }}
+            fedorapython/fedora-python-tox:${{ matrix.arch }}-f${{ env.FEDORA_VERSION }}
       - name: Test local project
         env:
           TOXENV: ${{ matrix.toxenv }}
@@ -72,10 +77,12 @@ jobs:
           context: .
           platforms: linux/${{ matrix.arch }}
           push: true
-          tags: fedorapython/fedora-python-tox:${{ matrix.arch }}
+          tags: |
+            fedorapython/fedora-python-tox:${{ matrix.arch }}
+            fedorapython/fedora-python-tox:${{ matrix.arch }}-f${{ env.FEDORA_VERSION }}
 
   release:
-    name: 'Update and test the :latest manifest'
+    name: 'Update and test manifests'
     if: github.event_name == 'push' || github.event_name == 'schedule'
     needs: build-and-push
     runs-on: ubuntu-latest
@@ -89,6 +96,7 @@ jobs:
         run: >
           for arch in amd64 arm64 ppc64le s390x; do
             docker pull fedorapython/fedora-python-tox:$arch;
+            docker pull fedorapython/fedora-python-tox:${arch}-f${{ env.FEDORA_VERSION }};
           done
       - name: Create and push manifest for the :latest tag
         env:
@@ -103,3 +111,16 @@ jobs:
       - name: Test the latest manifest
         run: |
           docker manifest inspect fedorapython/fedora-python-tox:latest | grep '"architecture":' | grep -Ez '(.*(amd64|arm64|ppc64le|s390x).*){4}'
+      - name: Create and push manifest for the versioned tag
+        env:
+          DOCKER_CLI_EXPERIMENTAL: enabled
+        run: >
+          docker manifest create fedorapython/fedora-python-tox:f${{ env.FEDORA_VERSION }}
+          fedorapython/fedora-python-tox:amd64-f${{ env.FEDORA_VERSION }}
+          fedorapython/fedora-python-tox:arm64-f${{ env.FEDORA_VERSION }}
+          fedorapython/fedora-python-tox:ppc64le-f${{ env.FEDORA_VERSION }}
+          fedorapython/fedora-python-tox:s390x-f${{ env.FEDORA_VERSION }};
+          docker manifest push fedorapython/fedora-python-tox:f${{ env.FEDORA_VERSION }};
+      - name: Test the versioned manifest
+        run: |
+          docker manifest inspect fedorapython/fedora-python-tox:f${{ env.FEDORA_VERSION }} | grep '"architecture":' | grep -Ez '(.*(amd64|arm64|ppc64le|s390x).*){4}'


### PR DESCRIPTION
With this change, all container images we push to the Docker hub will have two tags: `:arch` and `:arch-fXX`. Also, there is a new manifest for all `:arch-fXX` container images `:fXX`. In that way, when we soon switch to Fedora 35, container images `:arch-f34` and the manifest `:f34` should stay untouched possibly to use for users who need older Pythons.

I've run the action in my fork so you can already see the results in: https://hub.docker.com/repository/docker/fedorapython/fedora-python-tox/tags?page=1&ordering=last_updated 