### PR TITLE
On the CI, lower the amount of tox envs on arm64

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -23,11 +23,11 @@ jobs:
           - arch: amd64
             toxenv: py27,py36,py37,py38,py39,py310,py311,py312,py313,pypy,pypy39,pypy310
           - arch: arm64
-            toxenv: py38,py39,py311
+            toxenv: py312
           - arch: ppc64le
             toxenv: py37,py38,py311
           - arch: s390x
-            toxenv: py36,py38,py311
+            toxenv: py39,py310,py312
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
The arm64 job is much slower than others.

Also, update some Pythons.