### PR TITLE
Allow spaces in $DNF_INSTALL

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -63,7 +63,7 @@ jobs:
         env:
           TOXENV: ${{ matrix.toxenv }}
         run: |
-          docker run --rm --platform linux/${{ matrix.arch }} -e DNF_INSTALL="libffi-devel pkgconfig(libgit2) /usr/bin/cowsay" fedorapython/fedora-python-tox:${{ matrix.arch }} sh -c "/run_tests.sh; pip install -I --no-deps --compile --no-binary :all: cffi pygit2~=1.14.0 && cowsay DONE"
+          docker run --rm --platform linux/${{ matrix.arch }} -e DNF_INSTALL="libffi-devel 'pkgconfig(libgit2) >= 1.7' /usr/bin/cowsay" fedorapython/fedora-python-tox:${{ matrix.arch }} sh -c "/run_tests.sh; pip install -I --no-deps --compile --no-binary :all: cffi pygit2~=1.14.0 && cowsay DONE"
       - name: Test external project with WORKDIR
         run: |
           docker run --rm --platform linux/${{ matrix.arch }} -e TOXENV=py310-minimal -e GIT_URL=https://github.com/trezor/trezor-firmware.git -e WORKDIR=python fedorapython/fedora-python-tox:${{ matrix.arch }}

--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ You can install packages by any RPM *Provides*, for example:
 * pkgconfig names, e.g. `pkgconfig(libgit2)`, or
 * commands, e.g. `/usr/bin/cowsay`.
 
+Complex specifications including spaces have to be enclosed in single quotes
+inside the double quotes. For example: `-e DNF_INSTALL="libyaml-devel 'pytest > 7'"`
+
 # WORKDIR
 
 If your `tox.ini` file is not in the root directory of your project, set `WORKDIR` to the path you want to cd to before the tests are executed.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -10,7 +10,7 @@ if [ ! -z $GIT_URL ]; then
 fi
 
 if [ ! -z "$DNF_INSTALL" ]; then
-    dnf -y --setopt=tsflags=nodocs --setopt=deltarpm=false install $DNF_INSTALL
+    echo $DNF_INSTALL | xargs dnf -y --setopt=tsflags=nodocs --setopt=deltarpm=false install
 fi
 
 # Mark the current directory as safe for Git:


### PR DESCRIPTION
Resolves: https://github.com/fedora-python/fedora-python-tox/issues/74

Tested with:

```
podman run --rm -it -v $PWD:/src -w /src -e DNF_INSTALL="libyaml-devel libgit2-devel 'pytest > 7'" -e TOXENV=py313 fedora-python-tox:dnf_spaces
```

with a custom local build of the container image and it works fine.