### PR TITLE
Temporarily disable CI test that builds wheel of pygit2

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -59,11 +59,12 @@ jobs:
           TOXENV: ${{ matrix.toxenv }}
         run: |
           docker run --rm --platform linux/${{ matrix.arch }} -v $PWD/example_project:/src -w /src -e TOXENV -e TOX_PARAMS="-p auto" fedorapython/fedora-python-tox:${{ matrix.arch }}
-      - name: Test dnf install and wheel build
-        env:
-          TOXENV: ${{ matrix.toxenv }}
-        run: |
-          docker run --rm --platform linux/${{ matrix.arch }} -e DNF_INSTALL="libffi-devel 'pkgconfig(libgit2) >= 1.7' /usr/bin/cowsay" fedorapython/fedora-python-tox:${{ matrix.arch }} sh -c "/run_tests.sh; pip install -I --no-deps --compile --no-binary :all: cffi pygit2~=1.14.0 && cowsay DONE"
+      # Re-enable this test when switching from f40 to f41
+      # - name: Test dnf install and wheel build
+      #   env:
+      #     TOXENV: ${{ matrix.toxenv }}
+      #   run: |
+      #     docker run --rm --platform linux/${{ matrix.arch }} -e DNF_INSTALL="libffi-devel 'pkgconfig(libgit2) >= 1.7' /usr/bin/cowsay" fedorapython/fedora-python-tox:${{ matrix.arch }} sh -c "/run_tests.sh; pip install -I --no-deps --compile --no-binary :all: cffi pygit2~=1.14.0 && cowsay DONE"
       - name: Test external project with WORKDIR
         run: |
           docker run --rm --platform linux/${{ matrix.arch }} -e TOXENV=py3 -e GIT_URL=https://github.com/Netflix/nflxprofile.git -e WORKDIR=python fedorapython/fedora-python-tox:${{ matrix.arch }}


### PR DESCRIPTION
For some unreproducible reason, gcc fails on CI with exit code -11 - that should mean "segfault".

Fixes: https://github.com/fedora-python/fedora-python-tox/issues/80